### PR TITLE
Update asciimathml.py

### DIFF
--- a/asciimathml.py
+++ b/asciimathml.py
@@ -701,8 +701,8 @@ symbols["vec"] = element_factory("mover", element_factory("mo", u"\u2192"), _ari
 symbols["dot"] = element_factory("mover", element_factory("mo", u"."), _arity=1, _swap=1)
 symbols["ddot"] = element_factory("mover", element_factory("mo", u".."), _arity=1, _swap=1)
 symbols["ul"] = element_factory("munder", element_factory("mo", u"\u0332"), _arity=1, _swap=1)
-symbols["ubrace"] = element_factory("munder", element_factory("mo",  "\u23DF"), _swap=True, _arity=1)
-symbols["obrace"] = element_factory("mover", element_factory("mo", "\u23DE"), _swap=True, _arity=1)
+symbols["ubrace"] = element_factory("munder", element_factory("mo",  u"\u23DF"), _swap=True, _arity=1)
+symbols["obrace"] = element_factory("mover", element_factory("mo", u"\u23DE"), _swap=True, _arity=1)
 
 symbols["sqrt"] = element_factory("msqrt", _arity=1)
 symbols["root"] = element_factory("mroot", _arity=2, _swap=True)

--- a/mdx_asciimathml.py
+++ b/mdx_asciimathml.py
@@ -24,7 +24,7 @@ class ASCIIMathMLExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):
         self.md = md
 
-        RE = re.compile(r'^(.*?)\$\$([^\$]*)\$\$(.*?)!', re.M) # $$ a $$
+        RE = r'\$\$([^\$]*)\$\$'
 
         md.inlinePatterns.add('', ASCIIMathMLPattern(RE), '_begin')
 
@@ -32,8 +32,6 @@ class ASCIIMathMLExtension(markdown.Extension):
         pass
 
 class ASCIIMathMLPattern(markdown.inlinepatterns.Pattern):
-    def getCompiledRegExp(self):
-        return re.compile(r'^(.*?)\$\$([^\$]*)\$\$(.*?)!', re.M) # $$ a $$
 
     def handleMatch(self, m):
         if markdown.version_info < (2, 1, 0):

--- a/mdx_asciimathml.py
+++ b/mdx_asciimathml.py
@@ -24,7 +24,7 @@ class ASCIIMathMLExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):
         self.md = md
 
-        RE = re.compile(r'^(.*)\$\$([^\$]*)\$\$(.*)$', re.M) # $$ a $$
+        RE = re.compile(r'^(.*?)\$\$([^\$]*)\$\$(.*?)!', re.M) # $$ a $$
 
         md.inlinePatterns.add('', ASCIIMathMLPattern(RE), '_begin')
 
@@ -33,7 +33,7 @@ class ASCIIMathMLExtension(markdown.Extension):
 
 class ASCIIMathMLPattern(markdown.inlinepatterns.Pattern):
     def getCompiledRegExp(self):
-        return re.compile(r'^(.*)\$\$([^\$]*)\$\$(.*)$', re.M) # $$ a $$
+        return re.compile(r'^(.*?)\$\$([^\$]*)\$\$(.*?)!', re.M) # $$ a $$
 
     def handleMatch(self, m):
         if markdown.version_info < (2, 1, 0):


### PR DESCRIPTION
Symbols "ubrace" and "obrace" get rendered as  \u23DF and \u23DE respectively using Python2.
Mandatory  Python2 unicode prefix u was missing on lines 704 and 705.
Both glitches should be fixed now. 
